### PR TITLE
Fix rendering clears within draw loops

### DIFF
--- a/src/Screens/screen_main_game.c
+++ b/src/Screens/screen_main_game.c
@@ -12,6 +12,8 @@ void UpdateGameScreen(void) {
 }
 
 void DrawGameScreen(void) {
+    ClearBackground(BLACK);
+
     const char *text = "In The game screen!";
     int fontSize = 40;
     int textWidth = MeasureText(text, fontSize);
@@ -23,7 +25,6 @@ void DrawGameScreen(void) {
 }
 
 void UnloadGameScreen(void) {
-    ClearBackground(BLACK);
 }
 
 GameScreen FinisGameScreen(void) {

--- a/src/Screens/screen_menu.c
+++ b/src/Screens/screen_menu.c
@@ -55,8 +55,6 @@ void InitMenuScreen(void) {
 }
 
 void UpdateMenuScreen(void) {
-    ClearBackground(BLACK);
-
     UpdateUiButton(&startButton);
     UpdateUiButton(&quitButton);
 
@@ -71,6 +69,8 @@ void UpdateMenuScreen(void) {
 }
 
 void DrawMenuScreen(void) {
+    ClearBackground(BLACK);
+
     // Title
     //********************************************************
     const char *title = "Hyper Paddle";


### PR DESCRIPTION
## Summary
- move menu screen ClearBackground call into DrawMenuScreen to respect raylib draw boundaries
- clear the backbuffer at the start of DrawGameScreen and remove rendering from UnloadGameScreen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69015e154e44832ca3a6c2f582e31a37