### PR TITLE
Fix include paths for paddle and game manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(${PROJECT_NAME} src/main.c
         src/GameManager/Game_Manager.h
         src/GameManager/Main_Game.c
 )
+# Ensure project headers under include/ are discoverable
+target_include_directories(${PROJECT_NAME} PRIVATE include)
 #set(raylib_VERBOSE 1)
 target_link_libraries(${PROJECT_NAME} raylib)
 

--- a/src/GameManager/Main_Game.c
+++ b/src/GameManager/Main_Game.c
@@ -4,7 +4,7 @@
 ****************************************************************/
 
 #include "Game_Manager.h"
-#include "../../../../include/GameObjects/Paddle/Paddle.h"
+#include "GameObjects/Paddle/Paddle.h"
 
 float deltaTime = 0;
 

--- a/src/GameObjects/Paddle/Paddle.c
+++ b/src/GameObjects/Paddle/Paddle.c
@@ -3,7 +3,7 @@
 *  Created by Squid on 10/28/2025.
 ****************************************************************/
 
-#include "../../../include/GameObjects/Paddle/Paddle.h"
+#include "GameObjects/Paddle/Paddle.h"
 
 
 

--- a/src/Screens/screen_main_game.c
+++ b/src/Screens/screen_main_game.c
@@ -4,7 +4,7 @@
 ****************************************************************/
 
 #include "screens.h"
-#include "../../Src/GameManager/Game_Manager.h"
+#include "../GameManager/Game_Manager.h"
 
 static GameScreen nextScreen;
 


### PR DESCRIPTION
## Summary
- reference the paddle header using the include directory instead of deep relative paths
- correct the main game screen's include of the manager header so it matches the actual directory and casing
- expose the top-level include directory in CMake so the new include directives resolve cleanly

## Testing
- cmake -S . -B build *(fails: cannot download raylib dependency because external network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_690294beb3b0832ca98a0d9063e5eef3