### PR TITLE
Fix Ball source path casing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ add_executable(${PROJECT_NAME} src/main.c
         include/Systems/KeybordManager/KeybordManager.h
         src/Systems/KeybordManager.c
         include/GameObjects/Ball/Ball.h
-        src/GameObjects/Ball/ball.c
+        src/GameObjects/Ball/Ball.c
 )
 # Ensure project headers under include/ are discoverable
 target_include_directories(${PROJECT_NAME} PRIVATE include)


### PR DESCRIPTION
## Summary
- correct the Ball source file path in CMakeLists.txt to match the file's casing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690415d1d5a4832c9e0e9814eef7cb0d