### PR TITLE
Fix deltaTime smoothing state sharing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(${PROJECT_NAME} src/main.c
         include/Systems/deltaTime.h
         include/Systems/KeybordManager/KeybordManager.h
         src/Systems/KeybordManager.c
+        src/Systems/deltaTime.c
         include/GameObjects/Ball/Ball.h
         src/GameObjects/Ball/Ball.c
 )

--- a/include/Systems/deltaTime.h
+++ b/include/Systems/deltaTime.h
@@ -11,24 +11,6 @@
 // - Clamps very large frame times (e.g., when dragging the window or after stalls)
 // - Applies an EMA to reduce micro-jitter without adding noticeable latency
 // Tune constants below to your preference.
-static float deltaTime(void) {
-    // Reasonable bounds: allow slow-mo down to 20 FPS equivalent, block huge spikes
-    const float MAX_DT = 0.05f;   // 50 ms (cap)
-    const float MIN_DT = 0.0f;    // never negative
+float deltaTime(void);
 
-    // EMA smoothing factor: 0 = no update, 1 = no smoothing. 0.1–0.3 is typical.
-    const float SMOOTHING_ALPHA = 0.2f;
-
-    // Start near 60 FPS to avoid initial burst
-    static float smoothed = 1.0f / 60.0f;
-
-    float dt = GetFrameTime();
-    if (dt < MIN_DT) dt = MIN_DT;
-    if (dt > MAX_DT) dt = MAX_DT;
-
-    // Exponential moving average
-    smoothed += (dt - smoothed) * SMOOTHING_ALPHA;
-    return smoothed;
-}
-
-#endif //HYPER_PADDLE_DELTATIME_H
+#endif // HYPER_PADDLE_DELTATIME_H

--- a/src/Systems/deltaTime.c
+++ b/src/Systems/deltaTime.c
@@ -1,0 +1,25 @@
+#include "Systems/deltaTime.h"
+
+// Spike-resistant delta time with light smoothing.
+// - Clamps very large frame times (e.g., when dragging the window or after stalls)
+// - Applies an EMA to reduce micro-jitter without adding noticeable latency
+// Tune constants below to your preference.
+float deltaTime(void) {
+    // Reasonable bounds: allow slow-mo down to 20 FPS equivalent, block huge spikes
+    const float MAX_DT = 0.05f;   // 50 ms (cap)
+    const float MIN_DT = 0.0f;    // never negative
+
+    // EMA smoothing factor: 0 = no update, 1 = no smoothing. 0.1–0.3 is typical.
+    const float SMOOTHING_ALPHA = 0.2f;
+
+    // Start near 60 FPS to avoid initial burst
+    static float smoothed = 1.0f / 60.0f;
+
+    float dt = GetFrameTime();
+    if (dt < MIN_DT) dt = MIN_DT;
+    if (dt > MAX_DT) dt = MAX_DT;
+
+    // Exponential moving average
+    smoothed += (dt - smoothed) * SMOOTHING_ALPHA;
+    return smoothed;
+}


### PR DESCRIPTION
## Summary
- move the deltaTime implementation into a single source file so the smoothing state is shared across translation units
- update the header declaration and build configuration to compile the shared implementation

## Testing
- cmake -S . -B build *(fails: proxy blocked download of raylib 5.5)*

------
https://chatgpt.com/codex/tasks/task_e_690559cea020832cacd74c3b37a20afd