### PR TITLE
Fix bottom bound clamping in HandleVerticalBounds

### DIFF
--- a/src/GameObjects/Ball/Ball.c
+++ b/src/GameObjects/Ball/Ball.c
@@ -60,10 +60,10 @@ void HandleVerticalBounds(Ball *ball) {
     }
 
     const float screenBottomSide = (float)GetScreenHeight();
-    const float ballBottomSide = ball->Shape.y - ball->Shape.height;
+    const float ballBottomSide = ball->Shape.y + ball->Shape.height;
 
-    if (ball->Shape.y >= screenBottomSide) {
-        ball->Shape.y = ballBottomSide - ball->Shape.height;
+    if (ballBottomSide >= screenBottomSide) {
+        ball->Shape.y = screenBottomSide - ball->Shape.height;
         ball->Velocity.y = -ball->Velocity.y;
     }
 }


### PR DESCRIPTION
## Summary
- compute the ball's bottom edge using its height when checking the screen boundary
- clamp the ball position to the bottom edge and invert velocity when it reaches the lower boundary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905b8ce4058832cb7aa7224a51a5bac