### PR TITLE
Fix Linux build by replacing Windows-specific string formatting

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -5,8 +5,8 @@
 *  Created by Squid on 10/25/2025
 ****************************************************************/
 
-#include <strsafe.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include "raylib.h"
 #include "Screens/screens.h"
 
@@ -27,7 +27,7 @@ void Unload(void);
 int main(void)
 {
     // Combine the title and version into a single string.
-    StringCchPrintfA(gameTitle, sizeof(gameTitle), "%s %s", Hyp_Paddle_Title, Hyp_Paddle_Version);
+    snprintf(gameTitle, sizeof(gameTitle), "%s %s", Hyp_Paddle_Title, Hyp_Paddle_Version);
 
     // Init the Game/Items
     InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, gameTitle);


### PR DESCRIPTION
## Summary
- replace the Windows-only StringCchPrintfA usage with standard snprintf
- include stdio instead of the unavailable strsafe header

## Testing
- cmake .. # fails: raylib dependency cannot be downloaded due to proxy restrictions

------
https://chatgpt.com/codex/tasks/task_e_69080d50a1cc832ca93ec007c29b5b0b